### PR TITLE
Add checksum checking to GPS message parser

### DIFF
--- a/gps_module.h
+++ b/gps_module.h
@@ -3,28 +3,6 @@
 
 #include <stdint.h>
 
-// Order matters for this enum, matches the order of GPGGA fields
-enum PARSER_STATE {
-    P_IDLE = 0,
-    P_MSG_TYPE,
-    P_TIMESTAMP,
-    P_LATITUDE,
-    P_LATITUDE_DIR_NS,
-    P_LONGITUDE,
-    P_LONGITUDE_DIR_EW,
-    P_QUALITY,          // Quality Indicator:
-                        // 1 = Uncorrected coordinate
-                        // 2 = Differentially correct coordinate (e.g., WAAS, DGPS)
-                        // 4 = RTK Fix coordinate (centimeter precision)
-                        // 5 = RTK Float (decimeter precision.
-                        // 6 = Dead reckoning mode
-    P_NUM_SATELLITES,
-    P_HDOP,             // horizontal dilution of precision
-    P_ALTITUDE_ANTENNA,
-    P_ALTITUDE_UNITS,
-    P_STOP,
-};
-
 void gps_init(void);
 
 void assemble_can_msgs(void);

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -67,9 +67,9 @@
         <targetDevice>PIC18F26K83</targetDevice>
         <targetHeader></targetHeader>
         <targetPluginBoard></targetPluginBoard>
-        <platformTool></platformTool>
+        <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC8</languageToolchain>
-        <languageToolchainVersion>2.31</languageToolchainVersion>
+        <languageToolchainVersion>2.36</languageToolchainVersion>
         <platform>2</platform>
       </toolsSet>
       <packs>


### PR DESCRIPTION
It has been observed that the UART messages can get corrupted sometimes and making their ways to the bus.

Before this commit, the parser sends out a CAN message as soon as a message field is parsed. With this change all the messages are sent together at the end of the message after checksum check is passed.

This has an added benefit that all GPS CAN messages from the same NMEA message would get the same timestamp.